### PR TITLE
Update plugin to support Logstash 2.1.0.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2015 Elastics.co <http://www.elastics.co>
+Copyright (c) 2012-2015 Elastic.co <http://www.elastic.co>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/logstash-filter-bytes2human.gemspec
+++ b/logstash-filter-bytes2human.gemspec
@@ -1,14 +1,14 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-bytes2human'
-  s.version         = '0.1.0'
+  s.version         = '0.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Convert to and from human readable bytes."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
-  s.authors         = ["Elastics.co"]
-  s.email           = 'info@elastics.co'
-  s.homepage        = "http://www.elastics.co/guide/en/logstash/current/index.html"
-  s.require_paths = ["lib"]
+  s.authors         = ["Elastic.co"]
+  s.email           = 'info@elastic.co'
+  s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
+  s.require_paths   = ["lib"]
 
   # Files
   s.files = `git ls-files`.split($\)
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
+  s.add_runtime_dependency "logstash-core", '>= 2.1.0', '< 3.0.0'
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/logstash-filter-bytes2human.gemspec
+++ b/logstash-filter-bytes2human.gemspec
@@ -11,7 +11,17 @@ Gem::Specification.new do |s|
   s.require_paths   = ["lib"]
 
   # Files
-  s.files = `git ls-files`.split($\)
+  s.files = Dir[
+    'lib/**/*',
+    'spec/**/*',
+    'vendor/**/*',
+    '*.gemspec',
+    '*.md',
+    'CONTRIBUTORS',
+    'Gemfile',
+    'LICENSE',
+    'NOTICE.TXT'
+  ]
 
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
I installed and ran Logstash 2.1.0 locally with the bytes2human plugin and found that everything worked just fine. Thus, this pull request is simply to update the gemspec dependency such that anyone running Logstash 2.1.0 can run `bin/plugin install logstash-filter-bytes2human` and download+install the gem from Rubygems.org. (Obviously you'll have to `rake push` to update the gem once the pull request is merged.)
