### PR TITLE
Fix the event field access for logstash >= 5.0

### DIFF
--- a/lib/logstash/filters/bytes2human.rb
+++ b/lib/logstash/filters/bytes2human.rb
@@ -51,7 +51,7 @@ class LogStash::Filters::Bytes2Human < LogStash::Filters::Base
   def convert(event)
     @convert.each do |field, direction|
       next unless event.include?(field)
-      original = event[field]
+      original = event.get(field)
       
       if original.nil?
         next
@@ -72,7 +72,7 @@ class LogStash::Filters::Bytes2Human < LogStash::Filters::Base
           value = Filesize.from(original).to_i;
         end
       end
-      event[field] = value
+      event.set(field, value)
     end
   end # def convert
 


### PR DESCRIPTION
Starting with logstash 5.0, the access to the event should be done differently, see https://www.elastic.co/guide/en/logstash/5.0/breaking-changes.html#_ruby_filter_and_custom_plugin_developers.